### PR TITLE
doc(readme): count => size

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -18,7 +18,7 @@ Endpoint: /1/queries/count/year[-month[-day[ hour[:minutes]]]]
 
 ## K most frequent queries in a time range
 
-Endpoint: /1/queries/popular/year[-month[-day[ hour[:minutes]]]]?count=n";
+Endpoint: /1/queries/popular/year[-month[-day[ hour[:minutes]]]]?size=n";
 
 /// Wrapper for percent decoding
 fn  decode_str_safe(data: &str) -> Option<String> {


### PR DESCRIPTION
The query param for the popular endpoint is named `size` not `count`